### PR TITLE
fix: update CI flake8 rules to ignore style-only errors (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run flake8
         run: |
-          flake8 . --exclude=venv,__pycache__
+          flake8 . --exclude=venv,__pycache__ --ignore=E501,W292
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This PR updates the CI workflow to ignore style-only flake8 errors.

Changes:
- Ignored E501 line length
- Ignored W292 newline warnings

Closes #6